### PR TITLE
Add client 2.5 and server 10.2.0 to the matrix (most recent releases)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -86,6 +86,8 @@ services:
 
 matrix:
   include:
+    # Test client versions with daily master server version
+
     - CLIENT_VERSION: master
       SERVER_VERSION: daily-master
       TEST_SUITE: reshareDir
@@ -266,6 +268,8 @@ matrix:
       SERVER_VERSION: daily-master
       TEST_SUITE: nplusone
 
+    # Test client versions with daily stable10 server version
+
     - CLIENT_VERSION: master
       SERVER_VERSION: daily-stable10
       TEST_SUITE: reshareDir
@@ -444,4 +448,66 @@ matrix:
 
     - CLIENT_VERSION: 2.4
       SERVER_VERSION: daily-stable10
+      TEST_SUITE: nplusone
+
+    # Test latest client release with latest server release
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: reshareDir
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: scrapeLogFile
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: shareDir
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: shareFile
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: shareGroup
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: sharePermissions
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: uploadFiles
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: basicSync
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: concurrentDirRemove
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: shareLink
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: shareMountInit
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: sharePropagationGroups
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: sharePropagationInsideGroups
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
+      TEST_SUITE: chunking
+
+    - CLIENT_VERSION: 2.5
+      SERVER_VERSION: 10.2.0
       TEST_SUITE: nplusone


### PR DESCRIPTION
@tboerger @patrickjahns would be good to have it, for reference to other failing tests (compare logs even)