### PR TITLE
Use PHP 7.4 to run owncloud 10

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -7,7 +7,7 @@ def main(ctx):
         },
     ]
 
-    client_versions = ["2.8", "2.9"]
+    client_versions = ["2.9", "2.10"]
 
     test_suites = [
         "reshareDir",

--- a/.drone.star
+++ b/.drone.star
@@ -75,7 +75,7 @@ def smashbox(ctx, client_version, server_version, test_suite):
             },
             {
                 "name": "owncloud-server",
-                "image": "owncloud/base:bionic",
+                "image": "owncloud/base:20.04",
                 "pull": "always",
                 "detach": True,
                 "environment": {


### PR DESCRIPTION
1) PHP 7.2 support was dropped in oc10 master last week - so usse `owncloud/base:20.04` which has a later version of PHP
https://drone.owncloud.com/owncloud/smashbox-testing/1618/1/6
```
This version of ownCloud requires at least PHP 7.3.0
You are currently running PHP 7.2.24-0ubuntu0.18.04.6. Please update your PHP version.
```

2) Test 2.9 and 2.10, which have daily builds in https://download.owncloud.com/desktop/ownCloud/daily
https://drone.owncloud.com/owncloud/smashbox-testing/1621/1/8
```
OWNCLOUD_REPO_URL=https://download.owncloud.com/desktop/ownCloud/daily/2.8/linux/Ubuntu_18.04
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: apt-key output should not be parsed (stdout is not a terminal)

100   119  100   119    0     0    782      0 --:--:-- --:--:-- --:--:--   782
gpg: no valid OpenPGP data found.
```

https://download.owncloud.com/desktop/ownCloud/daily does not have any 2.8 folder any more.
